### PR TITLE
fix #20: lsp progress depreacted get_progress_messages

### DIFF
--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -61,8 +61,8 @@ end
 function M.lsp_progress()
     local messages = {}
 
-    local nvim_version = vim.version()
-    if nvim_version.major > 0 or (nvim_version.major == 0 and nvim_version.minor > 9) then
+	-- get_progress_messages deprecated in favor of vim.lsp.status
+    if vim.lsp.status then
         local clients = vim.lsp.get_active_clients()
 
         vim.iter(clients):each(function(c)
@@ -78,6 +78,7 @@ function M.lsp_progress()
             end
         end)
     else
+		-- Support for older versions of Neovim
         messages = vim.lsp.util.get_progress_messages()
     end
 

--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -61,7 +61,8 @@ end
 function M.lsp_progress()
     local messages = {}
 
-    if vim.fn.has "nvim-0.10" then
+    local nvim_version = vim.version()
+    if nvim_version.major > 0 or (nvim_version.major == 0 and nvim_version.minor > 9) then
         local clients = vim.lsp.get_active_clients()
 
         vim.iter(clients):each(function(c)

--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -61,10 +61,10 @@ end
 function M.lsp_progress()
     local messages = {}
 
-    if vim.fn.has "neovim-0.10" then
-        local prog_msg = vim.lsp.util.get_progress_messages()
+    if vim.fn.has "nvim-0.10" then
+        local clients = vim.lsp.get_active_clients()
 
-        vim.iter(prog_msg):each(function(c)
+        vim.iter(clients):each(function(c)
             local msg = c.progress:pop()
             if msg and msg.value then
                 table.insert(messages, msg.value)

--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -43,27 +43,46 @@ end
 
 local function format_messages(messages)
 	local result = {}
-	local spinners = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' }
-	local ms = vim.loop.hrtime() / 1000000
-	local frame = math.floor(ms / 120) % #spinners
-	local i = 1
-	for _, msg in pairs(messages) do
-		-- Only display at most 2 progress messages at a time to avoid clutter
-		if i < 3 then
-			table.insert(result, (msg.percentage or 0) .. '%% ' .. (msg.title or ''))
-			i = i + 1
-		end
-	end
+    local spinners = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' }
+    local ms = vim.loop.hrtime() / 1000000
+    local frame = math.floor(ms / 120) % #spinners
+
+	table.insert(result, (messages.percentage or 0) .. '%% ' .. (messages.title or ""))
 	return table.concat(result, ' ') .. ' ' .. spinners[frame + 1]
 end
 
 -- REQUIRES LSP
 function M.lsp_progress()
-	local messages = vim.lsp.util.get_progress_messages()
-	if #messages == 0 then
-		return ''
-	end
-	return space..format_messages(messages)
+	local clients = vim.lsp.get_active_clients()
+    if vim.o.columns < 120 or #clients == 0 then
+        return ""
+    end
+
+    local msg_val = nil
+    vim.iter(clients):each(function(c)
+        if msg_val then
+            return
+        end
+
+        local msg = c.progress:pop()
+        if msg and msg.value then
+            msg_val = msg.value
+        end
+		-- Only display at most 2 progress messages at a time to avoid clutter
+        local i = 1
+		for pmsg in c.progress do
+            if pmsg and pmsg.value and i < 3 then
+                msg_val = pmsg.value
+				i = i + 1
+            end
+        end
+    end)
+
+    if not msg_val then
+        return ""
+    end
+
+    return space..format_messages(msg_val)
 end
 
 -- REQUIRES NVIM LIGHTBULB

--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -42,18 +42,18 @@ function M.diagnostics()
 end
 
 local function format_messages(messages)
-	local result = {}
+    local result = {}
     local spinners = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' }
     local ms = vim.loop.hrtime() / 1000000
     local frame = math.floor(ms / 120) % #spinners
 
-	table.insert(result, (messages.percentage or 0) .. '%% ' .. (messages.title or ""))
-	return table.concat(result, ' ') .. ' ' .. spinners[frame + 1]
+    table.insert(result, (messages.percentage or 0) .. '%% ' .. (messages.title or ""))
+    return table.concat(result, ' ') .. ' ' .. spinners[frame + 1]
 end
 
 -- REQUIRES LSP
 function M.lsp_progress()
-	local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_active_clients()
     if vim.o.columns < 120 or #clients == 0 then
         return ""
     end
@@ -68,12 +68,12 @@ function M.lsp_progress()
         if msg and msg.value then
             msg_val = msg.value
         end
-		-- Only display at most 2 progress messages at a time to avoid clutter
+        -- Only display at most 2 progress messages at a time to avoid clutter
         local i = 1
-		for pmsg in c.progress do
+        for pmsg in c.progress do
             if pmsg and pmsg.value and i < 3 then
                 msg_val = pmsg.value
-				i = i + 1
+                i = i + 1
             end
         end
     end)

--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -61,7 +61,7 @@ end
 function M.lsp_progress()
     local messages = {}
 
-	-- get_progress_messages deprecated in favor of vim.lsp.status
+    -- get_progress_messages deprecated in favor of vim.lsp.status
     if vim.lsp.status then
         local clients = vim.lsp.get_active_clients()
 
@@ -78,7 +78,7 @@ function M.lsp_progress()
             end
         end)
     else
-		-- Support for older versions of Neovim
+        -- Support for older versions of Neovim
         messages = vim.lsp.util.get_progress_messages()
     end
 


### PR DESCRIPTION
Fix #20 the deprecated function `vim.lsp.util.get_progress_messages()`. 

As advised by neovim @ https://github.com/neovim/neovim/pull/23958

