### PR TITLE
s/lsp.lsp_progress/vim.lsp.status/

### DIFF
--- a/lua/modules/statusline.lua
+++ b/lua/modules/statusline.lua
@@ -141,7 +141,7 @@ function M.activeLine()
 
 	--Component: Lsp Progress
 	-- if lsp.lsp_progress()~= nil then
-	statusline = statusline .. lsp.lsp_progress()
+	statusline = statusline .. require('vim.lsp').status()
 	statusline = statusline .. '%#Statusline_LSP_Func# ' .. lsp.lightbulb()
 	-- end
 


### PR DESCRIPTION
ToT neovim is complaining that `lsp.lsp_progress` will be deprecated soon. Replacing as suggested by message.