### PR TITLE
fix: resolve deprecation warning for lsp clients

### DIFF
--- a/lua/sections/_lsp.lua
+++ b/lua/sections/_lsp.lua
@@ -63,7 +63,7 @@ function M.lsp_progress()
 
     -- get_progress_messages deprecated in favor of vim.lsp.status
     if vim.lsp.status then
-        local clients = vim.lsp.get_active_clients()
+        local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)()
 
         vim.iter(clients):each(function(c)
             local msg = c.progress:pop()


### PR DESCRIPTION
Try and use the `get_clients` function if available, otherwise, fallback to deprecated `get_active_clients` which will be removed in 0.12. The inline `or` condition should make the change backwards compatible with older versions of neovim.